### PR TITLE
Tweak READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 opam spin new https://github.com/tmattio/spin-dream.git
 ```
 
-You can see a generated project with the minimal setup in the [`example/`](example/) directory.
+You can see a generated project with the minimal setup and usage instructions
+in the [`example/`](example/) directory.
 
 ## What's included
 
@@ -25,7 +26,7 @@ You can see a generated project with the minimal setup in the [`example/`](examp
   - `lib/<project>_web` contains the API definition
   - `lib/<project>_app` contains an (optional) JavaScript application sent to clients
 - [X] Welcome page with a portal to Dream's ecosystem
-- [X] Unit tests suite with [Alcotest](https://github.com/mirage/alcotest)
+- [X] Unit test suite with [Alcotest](https://github.com/mirage/alcotest)
 - [X] CLI to configure server settings at runtime with [`dream-cli`](https://github.com/tmattio/dream-cli)
 - [X] (optional) [Docker](https://www.docker.com/) configuration files ready for deployment.
 - [X] (optional) [TailwindCSS](https://tailwindcss.com/) integrated with Dune

--- a/template/README.md
+++ b/template/README.md
@@ -10,11 +10,11 @@
 {{ project_description }}
 {%- endif %}
 
-## Setup your development environment
+## Set up your development environment
 
-You need Opam, you can install it by following [Opam's documentation](https://opam.ocaml.org/doc/Install.html).
+You need opam. You can install it by following [opam's documentation](https://opam.ocaml.org/doc/Install.html).
 
-With Opam installed, you can install the dependencies in a new local switch with:
+With opam installed, you can install the dependencies in a new local switch with:
 
 ```bash
 make switch
@@ -48,9 +48,9 @@ make watch
 
 This will restart the server on filesystem changes and reload the pages automatically.
 
-### Running Tests
+### Running tests
 
-You can run the unit tests suites with:
+You can run the unit test suite with:
 
 ```bash
 make test
@@ -70,7 +70,7 @@ To serve the documentation:
 make servedoc
 ```
 
-### Repository Structure
+### Repository structure
 
 The following snippet describes {{ project_name }}'s repository structure.
 
@@ -80,23 +80,23 @@ The following snippet describes {{ project_name }}'s repository structure.
 |   Source for {{ project_slug }}'s binary. This links to the library defined in `lib/`.
 │
 ├── lib/
-|   Source for {{ project_name }}'s library. Contains {{ project_name }}'s core functionnalities.
+|   Source for {{ project_name }}'s library. Contains {{ project_name }}'s core functionalities.
 │
 ├── test/
 |   Unit tests and integration tests for {{ project_name }}.
 │
 ├── dune-project
 |   Dune file used to mark the root of the project and define project-wide parameters.
-|   For the documentation of the syntax, see https://dune.readthedocs.io/en/stable/dune-files.html#dune-project
+|   For the documentation of the syntax, see https://dune.readthedocs.io/en/stable/dune-files.html#dune-project.
 │
 ├── LICENSE
 │
 ├── Makefile
-|   Make file containing common development command.
+|   `Makefile` containing common development commands.
 │
 ├── README.md
 │
 └── {{ project_slug }}.opam
-    Opam package definition.
+    opam package definition.
     To know more about creating and publishing opam packages, see https://opam.ocaml.org/doc/Packaging.html.
 ```


### PR DESCRIPTION
- Consistent casing.
- "Set up" is spelled with a space when "set" is a verb and words can be inserted in the middle, e.g. "set that up."
- opam is not capitalized. See [opam project page](https://github.com/ocaml/opam#readme).

If you merge this, could you regenerate the example?